### PR TITLE
Catch exception for ms bot framework

### DIFF
--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -709,7 +709,7 @@ function Botkit(configuration) {
                                     }
                                 };
 
-                                if (this.task.botkit.config.typing) {
+                                if (this.task.botkit.config.typing && this.task.bot.replyWithTyping) {
                                     this.task.bot.replyWithTyping(this.source_message, outbound, sendMessage);
                                 } else {
                                     this.task.bot.reply(this.source_message, outbound, sendMessage);

--- a/lib/CoreBot.js
+++ b/lib/CoreBot.js
@@ -602,6 +602,18 @@ function Botkit(configuration) {
             }
         };
 
+        this.hasTypingOption = function() {
+            if (!this.task.botkit.config.typing) {
+                return false;
+            }
+
+            if (!this.task.bot.replyWithTyping) {
+                return false;
+            }
+
+            return true;
+        };
+
         this.tick = function() {
             var now = new Date();
 
@@ -709,7 +721,7 @@ function Botkit(configuration) {
                                     }
                                 };
 
-                                if (this.task.botkit.config.typing && this.task.bot.replyWithTyping) {
+                                if (this.hasTypingOption()) {
                                     this.task.bot.replyWithTyping(this.source_message, outbound, sendMessage);
                                 } else {
                                     this.task.bot.reply(this.source_message, outbound, sendMessage);


### PR DESCRIPTION
# What this PR does
- Catch the exception thrown when typing is activated in a MS Bot Framework Bot.

# Where should we start reviewing?
- lib/CoreBot.js

# Context
MS Bot Framework does not contain the `replyWithTyping` method, which causes it to crash when this feature is activated. This update will prevent Botkit to crash, as it first checks if this method exists, otherwise it will send an ordinary `reply` message.